### PR TITLE
Fix link to Tigase's mastodon profile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ social:
   - title: mastodon
     superclass: b
     class: mastodon
-    url: https://mastodon.technology/@tigase
+    url: https://fosstodon.org/@tigase
   - title: appstore
     class: download
     url: https://itunes.apple.com/us/app/beagleim-by-tigase-inc/id1445349494?l=pl&ls=1&mt=12


### PR DESCRIPTION
Used to be on mastodon.technology but is now on fosstodon.org.